### PR TITLE
Fix blank newline on `Render` func

### DIFF
--- a/bitbar.go
+++ b/bitbar.go
@@ -331,7 +331,7 @@ func (p *Plugin) Render() {
 	if p.SubMenu != nil {
 		output = output + renderSubMenu(p.SubMenu)
 	}
-	fmt.Println(output)
+	fmt.Print(output)
 }
 
 func renderSubMenu(d *SubMenu) string {


### PR DESCRIPTION
Closes #5

- App app lines already get a newline rendered via `\n` so `fmt.Println` was just adding a blank new line at the end